### PR TITLE
UseCase実装

### DIFF
--- a/internal/usecase/leaf.go
+++ b/internal/usecase/leaf.go
@@ -2,35 +2,41 @@ package usecase
 
 import (
 	"context"
+	"errors"
 
 	"github.com/umekikazuya/logleaf/internal/domain"
 	"github.com/umekikazuya/logleaf/internal/interface/repository"
 )
 
+// LeafUsecase provides application-level operations for managing Leaf entities.
+// It interacts with the LeafRepository to perform CRUD operations and other business logic.
 type LeafUsecase struct {
-	Repo repository.LeafRepository
+	repo repository.LeafRepository
 }
 
 func NewLeafUsecase(repo repository.LeafRepository) *LeafUsecase {
-	return &LeafUsecase{Repo: repo}
+	return &LeafUsecase{repo: repo}
 }
 
 func (u *LeafUsecase) ListLeaves(ctx context.Context, opts repository.ListOptions) ([]domain.Leaf, error) {
-	return u.Repo.List(ctx, opts)
+	return u.repo.List(ctx, opts)
 }
 
 func (u *LeafUsecase) GetLeaf(ctx context.Context, id string) (*domain.Leaf, error) {
-	return u.Repo.Get(ctx, id)
+	if id == "" {
+		return nil, errors.New("leaf ID cannot be empty")
+	}
+	return u.repo.Get(ctx, id)
 }
 
 func (u *LeafUsecase) AddLeaf(ctx context.Context, leaf *domain.Leaf) error {
-	return u.Repo.Put(ctx, leaf)
+	return u.repo.Put(ctx, leaf)
 }
 
 func (u *LeafUsecase) UpdateLeaf(ctx context.Context, id string, update *domain.Leaf) error {
-	return u.Repo.Update(ctx, id, update)
+	return u.repo.Update(ctx, id, update)
 }
 
 func (u *LeafUsecase) DeleteLeaf(ctx context.Context, id string) error {
-	return u.Repo.Delete(ctx, id)
+	return u.repo.Delete(ctx, id)
 }

--- a/internal/usecase/leaf.go
+++ b/internal/usecase/leaf.go
@@ -1,0 +1,36 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/umekikazuya/logleaf/internal/domain"
+	"github.com/umekikazuya/logleaf/internal/interface/repository"
+)
+
+type LeafUsecase struct {
+	Repo repository.LeafRepository
+}
+
+func NewLeafUsecase(repo repository.LeafRepository) *LeafUsecase {
+	return &LeafUsecase{Repo: repo}
+}
+
+func (u *LeafUsecase) ListLeaves(ctx context.Context, opts repository.ListOptions) ([]domain.Leaf, error) {
+	return u.Repo.List(ctx, opts)
+}
+
+func (u *LeafUsecase) GetLeaf(ctx context.Context, id string) (*domain.Leaf, error) {
+	return u.Repo.Get(ctx, id)
+}
+
+func (u *LeafUsecase) AddLeaf(ctx context.Context, leaf *domain.Leaf) error {
+	return u.Repo.Put(ctx, leaf)
+}
+
+func (u *LeafUsecase) UpdateLeaf(ctx context.Context, id string, update *domain.Leaf) error {
+	return u.Repo.Update(ctx, id, update)
+}
+
+func (u *LeafUsecase) DeleteLeaf(ctx context.Context, id string) error {
+	return u.Repo.Delete(ctx, id)
+}


### PR DESCRIPTION
This pull request introduces a new use case layer for managing "Leaf" entities. The primary changes include the creation of a `LeafUsecase` struct with methods to handle CRUD operations, leveraging a repository interface for database interactions.

### New use case layer for "Leaf" entities:
* [`internal/usecase/leaf.go`](diffhunk://#diff-7ec0c62adccc03cb174f0d493d6035870c3cee3208d5b8294476e9c1027ccde4R1-R36): Added a new `LeafUsecase` struct that provides methods for listing, retrieving, adding, updating, and deleting "Leaf" entities. These methods interact with the `LeafRepository` interface for database operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - リーフ情報の一覧取得、詳細取得、追加、更新、削除ができる機能を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->