### PR TITLE
Dockerfile整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ go.work.sum
 
 # os generated files
 .DS_Store
+
+# DynamoDB Local files
+dynamodb/
+
+# temporary files
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ go.work.sum
 .DS_Store
 
 # DynamoDB Local files
-dynamodb/
+docker/dynamodb/
 
 # temporary files
 tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o logleaf-server ./cmd/server/main.go
-RUN go install github.com/cosmtrek/air@latest
 
 FROM alpine:3.19
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.24-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o logleaf-server ./cmd/server/main.go
+RUN go install github.com/cosmtrek/air@latest
+
+FROM alpine:3.19
+WORKDIR /app
+COPY --from=builder /app/logleaf-server ./
+COPY .env .env
+EXPOSE 8080
+EXPOSE 8082
+ENV GIN_MODE=release
+CMD ["./logleaf-server"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,11 @@
+# 開発用Dockerfile（Dockerfile.dev）
+FROM golang:1.24-alpine
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go install github.com/air-verse/air@latest
+EXPOSE 8080
+EXPOSE 8082
+ENV GIN_MODE=debug
+CMD ["air", "-c", ".air.toml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,12 @@ services:
     depends_on:
       - dynamodb
   dynamodb:
-    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
+    command:
+      - "-jar"
+      - "DynamoDBLocal.jar"
+      - "-sharedDb"
+      - "-dbPath"
+      - "./data"
     image: "amazon/dynamodb-local:latest"
     container_name: logleaf-dynamodb
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: logleaf-app
+    ports:
+      - "8082:8082"
+    volumes:
+      - ./:/app
+      - ./tmp:/app/tmp
+    env_file:
+      - .env
+    command: ["air", "-c", ".air.toml"]
+    depends_on:
+      - dynamodb
+  dynamodb:
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
+    image: "amazon/dynamodb-local:latest"
+    container_name: logleaf-dynamodb
+    ports:
+      - "8000:8000"
+    volumes:
+      - "./docker/dynamodb:/home/dynamodblocal/data"
+    working_dir: /home/dynamodblocal


### PR DESCRIPTION
This pull request introduces Docker support for both production and development environments, as well as a `docker-compose` configuration for running the application with a local DynamoDB instance. The key changes include the addition of a production `Dockerfile`, a development `Dockerfile.dev`, and a `docker-compose.yml` file.

### Docker support:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R16): Added a production-ready Dockerfile that builds the Go application in a multi-stage process, sets the `GIN_MODE` to `release`, and exposes ports `8080` and `8082`.
* [`Dockerfile.dev`](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacR1-R11): Added a development Dockerfile that installs the `air` live-reloading tool, sets the `GIN_MODE` to `debug`, and exposes ports `8080` and `8082`.

### Docker Compose configuration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R31): Added a `docker-compose` configuration to run the application and a local DynamoDB instance. It includes volume mounting for live code updates, environment variable support, and port mappings for both the app (`8082`) and DynamoDB (`8000`).