### PR TITLE
既読/未読

### DIFF
--- a/internal/application/dto.go
+++ b/internal/application/dto.go
@@ -19,6 +19,7 @@ type LeafOutputDTO struct {
 	Title    string
 	URL      string
 	Platform string
+	Read     bool
 	Tags     []string
 	SyncedAt string
 }
@@ -37,6 +38,7 @@ func LeafDomainToOutputDTO(leaf *domain.Leaf) *LeafOutputDTO {
 		Title:    leaf.Title,
 		URL:      leaf.URL,
 		Platform: leaf.Platform,
+		Read:     leaf.Read,
 		Tags:     leaf.Tags,
 		SyncedAt: leaf.SyncedAt.Format(time.RFC3339),
 	}

--- a/internal/application/usecase.go
+++ b/internal/application/usecase.go
@@ -43,7 +43,27 @@ func (u *LeafUsecase) AddLeaf(ctx context.Context, dto *LeafInputDTO) (*domain.L
 }
 
 func (u *LeafUsecase) UpdateLeaf(ctx context.Context, update *LeafInputDTO) error {
-	leaf := LeafInputDTOToDomain(update)
+	leaf := domain.NewLeaf(
+		update.ID,
+		update.Title,
+		update.URL,
+		update.Platform,
+	)
+	if update.Tags != nil {
+		leaf.UpdateTags(update.Tags)
+	}
+	return u.repo.Update(ctx, leaf)
+}
+
+func (u *LeafUsecase) ReadLeaf(ctx context.Context, id string) error {
+	leaf, err := u.repo.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if leaf == nil {
+		return errors.New("leaf not found")
+	}
+	leaf.MarkAsRead()
 	return u.repo.Update(ctx, leaf)
 }
 

--- a/internal/interface/handler/handler.go
+++ b/internal/interface/handler/handler.go
@@ -101,6 +101,18 @@ func (h *LeafHandler) UpdateLeaf(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "updated"})
 }
 
+// PATCH /api/leaves/:id/read
+func (h *LeafHandler) ReadLeaf(c *gin.Context) {
+	id := c.Param("id")
+
+	err := h.Usecase.ReadLeaf(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "marked as read"})
+}
+
 // DELETE /api/leaves/:id
 func (h *LeafHandler) DeleteLeaf(c *gin.Context) {
 	id := c.Param("id")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ func NewRouter(leafHandler *handler.LeafHandler) *gin.Engine {
 		api.POST("/leaves", leafHandler.AddLeaf)
 		api.GET("/leaves/:id", leafHandler.GetLeaf)
 		api.PATCH("/leaves/:id", leafHandler.UpdateLeaf)
+		api.PATCH("/leaves/:id/read", leafHandler.ReadLeaf)
 		api.DELETE("/leaves/:id", leafHandler.DeleteLeaf)
 	}
 	return r


### PR DESCRIPTION
This pull request introduces a "mark as read" feature for the `Leaf` entity, allowing users to update a `Leaf`'s read status via a new API endpoint. Key changes include updates to the data transfer object, use case logic, handler, and routing.

### Feature Implementation: "Mark as Read"

#### Data Layer Updates:
* Added a new `Read` field to the `LeafOutputDTO` struct and updated the `LeafDomainToOutputDTO` function to include the `Read` property. (`internal/application/dto.go`) [[1]](diffhunk://#diff-a2f7de8e0b91ce1f670d8b3979a5a00cada0b37d0f4320e045390527747b3633R22) [[2]](diffhunk://#diff-a2f7de8e0b91ce1f670d8b3979a5a00cada0b37d0f4320e045390527747b3633R41)

#### Use Case Logic:
* Introduced a `ReadLeaf` method in the `LeafUsecase` to fetch a `Leaf` by ID, mark it as read, and update it in the repository. (`internal/application/usecase.go`)

#### API Handler:
* Added a new `ReadLeaf` handler to process `PATCH /api/leaves/:id/read` requests, invoking the `ReadLeaf` use case and returning appropriate responses. (`internal/interface/handler/handler.go`)

#### Routing:
* Registered the new `PATCH /api/leaves/:id/read` endpoint in the router. (`internal/server/server.go`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - リーフを「既読」としてマークするAPIエンドポイント（PATCH /api/leaves/:id/read）を追加しました。
  - リーフ情報に「既読」状態（Read）が含まれるようになりました。

- **バグ修正**
  - なし

- **ドキュメント**
  - なし

- **リファクタ**
  - なし

- **スタイル**
  - なし

- **テスト**
  - なし

- **その他**
  - なし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->