### PR TITLE
QiitaAPIからデータを取得

### DIFF
--- a/cmd/batch/qiita_sync.go
+++ b/cmd/batch/qiita_sync.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/joho/godotenv"
+	"github.com/umekikazuya/logleaf/internal/domain"
+	"github.com/umekikazuya/logleaf/internal/infrastructure/dynamo"
+	"github.com/umekikazuya/logleaf/internal/infrastructure/qiita"
+)
+
+func main() {
+	err := godotenv.Load()
+	if err != nil {
+		panic("Error loading .env file")
+	}
+	token := os.Getenv("QIITA_TOKEN")
+	user := os.Getenv("QIITA_USER")
+
+	if token == "" || user == "" {
+		fmt.Println("QIITA_TOKENとQIITA_USERを環境変数で指定してください")
+		os.Exit(1)
+	}
+	client := qiita.NewQiitaClient(token, user)
+	items, err := client.FetchStocks()
+	if err != nil {
+		fmt.Println("Qiita API取得エラー:", err)
+		os.Exit(1)
+	}
+
+	// DynamoDB設定
+	endpoint := os.Getenv("DYNAMO_ENDPOINT")
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = "ap-northeast-1"
+	}
+	cfg, err := config.LoadDefaultConfig(context.Background(),
+		config.WithRegion(region),
+	)
+	if err != nil {
+		panic("Failed to load AWS config: " + err.Error())
+	}
+	dynamoClient := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = &endpoint
+		}
+	})
+	tableName := os.Getenv("DYNAMO_TABLE")
+	if tableName == "" {
+		panic("DYNAMO_TABLE environment variable is required")
+	}
+	repo := dynamo.NewLeafDynamoRepository(dynamoClient, os.Getenv("DYNAMO_TABLE"))
+	ctx := context.Background()
+	for _, item := range items {
+		tags := make([]string, len(item.Tags))
+		for i, t := range item.Tags {
+			tags[i] = t.Name
+		}
+		leaf, err := domain.NewLeaf(item.Title, item.URL, "qiita", []string{}, false)
+		if err != nil {
+			fmt.Println("Leaf生成エラー:", err)
+			continue
+		}
+		_, err = repo.Put(ctx, leaf)
+		if err != nil {
+			fmt.Println("DynamoDB保存エラー:", err)
+		}
+		time.Sleep(200 * time.Millisecond) // API制限対策
+	}
+	fmt.Println("Qiitaストック記事の同期が完了しました")
+}

--- a/cmd/batch/qiita_sync.go
+++ b/cmd/batch/qiita_sync.go
@@ -27,7 +27,7 @@ func main() {
 	}
 	qiitaClient := qiita.NewQiitaClient(token, user)
 	items, err := qiitaClient.FetchStocksAll(
-		context.Background(),
+		ctx,
 	)
 	if err != nil {
 		fmt.Println("Qiita API取得エラー:", err)
@@ -41,7 +41,6 @@ func main() {
 		panic(err)
 	}
 	repo := dynamo.NewLeafDynamoRepository(dynamoClient, tableName)
-	ctx = context.Background()
 
 	// 既存LeafのURL一覧を取得して差分同期
 	leaves, err := repo.List(ctx, domain.ListOptions{Limit: 1000})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   app:
     build:

--- a/internal/infrastructure/dynamo/config.go
+++ b/internal/infrastructure/dynamo/config.go
@@ -1,0 +1,33 @@
+package dynamo
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+)
+
+// NewDynamoClientAndTable returns a DynamoDB client and table name using env vars (endpoint, region, table)
+func NewDynamoClientAndTable(ctx context.Context) (*dynamodb.Client, string, error) {
+	endpoint := os.Getenv("DYNAMO_ENDPOINT")
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = "ap-northeast-1"
+	}
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, "", err
+	}
+	client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = &endpoint
+		}
+	})
+	tableName := os.Getenv("DYNAMO_TABLE")
+	if tableName == "" {
+		return nil, "", errors.New("DYNAMO_TABLE environment variable is required")
+	}
+	return client, tableName, nil
+}

--- a/internal/infrastructure/qiita/client.go
+++ b/internal/infrastructure/qiita/client.go
@@ -1,0 +1,57 @@
+package qiita
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// QiitaItem represents a minimal Qiita article structure
+// 必要に応じてフィールドを追加
+type QiitaItem struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	URL   string `json:"url"`
+	Tags  []struct {
+		Name string `json:"name"`
+	} `json:"tags"`
+}
+
+// QiitaClient handles API requests
+type QiitaClient struct {
+	Token  string
+	UserID string
+}
+
+func NewQiitaClient(token, userID string) *QiitaClient {
+	return &QiitaClient{Token: token, UserID: userID}
+}
+
+// FetchStocks fetches stock articles from Qiita API
+func (c *QiitaClient) FetchStocks() ([]QiitaItem, error) {
+	url := fmt.Sprintf("https://qiita.com/api/v2/users/%s/stocks", c.UserID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Qiita API error: %s", resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var items []QiitaItem
+	if err := json.Unmarshal(body, &items); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/infrastructure/qiita/client.go
+++ b/internal/infrastructure/qiita/client.go
@@ -30,12 +30,17 @@ func NewQiitaClient(token, userID string) *QiitaClient {
 
 // FetchStocks fetches stock articles from Qiita API
 func (c *QiitaClient) FetchStocks() ([]QiitaItem, error) {
+	// パラメータをつけたい。per_page=100&page=1
 	url := fmt.Sprintf("https://qiita.com/api/v2/users/%s/stocks", c.UserID)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+c.Token)
+	q := req.URL.Query()
+	q.Set("per_page", "100")
+	q.Set("page", "1")
+	req.URL.RawQuery = q.Encode()
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/infrastructure/qiita/client.go
+++ b/internal/infrastructure/qiita/client.go
@@ -1,10 +1,12 @@
 package qiita
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 // QiitaItem represents a minimal Qiita article structure
@@ -20,43 +22,73 @@ type QiitaItem struct {
 
 // QiitaClient handles API requests
 type QiitaClient struct {
-	Token  string
-	UserID string
+	token  string
+	userId string
 }
 
 func NewQiitaClient(token, userID string) *QiitaClient {
-	return &QiitaClient{Token: token, UserID: userID}
+	return &QiitaClient{token: token, userId: userID}
 }
 
-// FetchStocks fetches stock articles from Qiita API
-func (c *QiitaClient) FetchStocks() ([]QiitaItem, error) {
-	// パラメータをつけたい。per_page=100&page=1
-	url := fmt.Sprintf("https://qiita.com/api/v2/users/%s/stocks", c.UserID)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
+// FetchStocksAll fetches stock articles from Qiita API
+func (c *QiitaClient) FetchStocksAll(ctx context.Context) ([]QiitaItem, error) {
+	allItems := make([]QiitaItem, 0)
+	page := 1
+	for {
+		items, hasMore, err := c.fetchStocks(ctx, page)
+		if err != nil {
+			return nil, err
+		}
+		allItems = append(allItems, items...)
+		if !hasMore {
+			break
+		}
+		page++
 	}
-	req.Header.Set("Authorization", "Bearer "+c.Token)
+	return allItems, nil
+}
+
+// fetchStockPage fetches a single page of stock articles from Qiita API
+func (c *QiitaClient) fetchStocks(ctx context.Context, page int) ([]QiitaItem, bool, error) {
+	url := fmt.Sprintf("https://qiita.com/api/v2/users/%s/stocks", c.userId)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// パラメータを設定
 	q := req.URL.Query()
 	q.Set("per_page", "100")
-	q.Set("page", "1")
+	q.Set("page", fmt.Sprintf("%d", page))
 	req.URL.RawQuery = q.Encode()
-	client := &http.Client{}
+
+	// 認証ヘッダーを設定
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	// APIリクエストを実行
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Qiita API error: %s", resp.Status)
+
+	// ステータスコードのチェック(200-299の範囲外はエラーとする)
+	if resp.StatusCode < 200 || 300 <= resp.StatusCode {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, false, fmt.Errorf("Qiita API error: %s, body: %s", resp.Status, string(body))
 	}
+	// レスポンスボディの読み込み
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
+	// JSON解析
 	var items []QiitaItem
 	if err := json.Unmarshal(body, &items); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return items, nil
+	return items, len(items) == 100, nil
 }

--- a/internal/server/di.go
+++ b/internal/server/di.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"os"
 
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/joho/godotenv"
 	"github.com/umekikazuya/logleaf/internal/application"
 	"github.com/umekikazuya/logleaf/internal/infrastructure/dynamo"
@@ -14,32 +12,11 @@ import (
 
 // アプリケーションの依存関係を初期化
 func InitializeDependencies() (*handler.LeafHandler, string) {
-	// Env設定
-	err := godotenv.Load()
-	if err != nil {
-		panic("Error loading .env file")
-	}
+	_ = godotenv.Load()
 
-	// DynamoDB設定
-	endpoint := os.Getenv("DYNAMO_ENDPOINT")
-	region := os.Getenv("AWS_REGION")
-	if region == "" {
-		region = "ap-northeast-1"
-	}
-	cfg, err := config.LoadDefaultConfig(context.Background(),
-		config.WithRegion(region),
-	)
+	client, tableName, err := dynamo.NewDynamoClientAndTable(context.Background())
 	if err != nil {
-		panic("Failed to load AWS config: " + err.Error())
-	}
-	client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
-		if endpoint != "" {
-			o.BaseEndpoint = &endpoint
-		}
-	})
-	tableName := os.Getenv("DYNAMO_TABLE")
-	if tableName == "" {
-		panic("DYNAMO_TABLE environment variable is required")
+		panic(err)
 	}
 
 	leafRepo := dynamo.NewLeafDynamoRepository(client, tableName)


### PR DESCRIPTION
This pull request introduces a new batch synchronization feature for Qiita stock articles and includes associated updates to the infrastructure and configuration files. The most important changes involve the addition of a new command-line tool for syncing data, the implementation of a Qiita API client, and updates to the `docker-compose.yml` file.

### New Feature: Qiita Stock Synchronization

* [`cmd/batch/qiita_sync.go`](diffhunk://#diff-cac4801d9249ffb839f209c05935eec089b3501a9956b25dc4c014d2f9e1af6bR1-R93): Added a new command-line tool for syncing Qiita stock articles with DynamoDB. This tool fetches articles from the Qiita API, compares them with existing entries in DynamoDB, and adds new articles while avoiding duplicates. It also handles environment variables for configuration and includes basic error handling.

### Infrastructure Updates

* [`internal/infrastructure/qiita/client.go`](diffhunk://#diff-ceae5325015ea7bd812b80ae25f563ab51a143cb1873cd7bb25ace4258980a3eR1-R62): Implemented a `QiitaClient` to interact with the Qiita API. The client fetches stock articles using the user's token and ID, processes API responses, and supports pagination.

### Configuration Updates

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1): Updated the Docker Compose configuration file. The version declaration (`version: '3.8'`) was removed, which may simplify compatibility across environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Qiitaのストック記事をDynamoDBに同期するバッチプログラムを追加しました。
  - Qiita APIとの連携機能を追加し、ユーザーのストック記事を取得できるようになりました。
- **その他**
  - docker-compose.ymlのバージョン宣言行を削除しました（サービス動作には影響ありません）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->