### PR TITLE
Docker環境整備

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o logleaf-server ./cmd/server/main.go
 FROM alpine:3.19
 WORKDIR /app
 COPY --from=builder /app/logleaf-server ./
+COPY .env .env
 EXPOSE 8080
-EXPOSE 8082
-EXPOSE 8082
 ENV GIN_MODE=release
 CMD ["./logleaf-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o logleaf-server ./cmd/server/main.go
 FROM alpine:3.19
 WORKDIR /app
 COPY --from=builder /app/logleaf-server ./
-COPY .env .env
 EXPOSE 8080
 ENV GIN_MODE=release
 CMD ["./logleaf-server"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,11 +1,10 @@
-# 開発用Dockerfile（Dockerfile.dev）
+# syntax=docker/dockerfile:1
 FROM golang:1.24-alpine
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN go install github.com/air-verse/air@latest
-EXPOSE 8080
 EXPOSE 8082
 ENV GIN_MODE=debug
 CMD ["air", "-c", ".air.toml"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Logleaf
+
+## 環境構築
+### 1. git clone
+```bash
+git clone https://github.com/umekikazuya/logleaf.git
+cd logleaf
+```
+### 2. Dockerイメージのビルド & コンテナの起動
+```bash
+docker-compose up --build
+```
+
+### 3. DynamoDB初期セットアップ
+```bash
+aws dynamodb create-table \
+  --table-name leaves \
+  --attribute-definitions \
+    AttributeName=pk,AttributeType=S \
+    AttributeName=sk,AttributeType=S \
+  --key-schema \
+    AttributeName=pk,KeyType=HASH \
+    AttributeName=sk,KeyType=RANGE \
+  --billing-mode PAY_PER_REQUEST \
+  --endpoint-url http://localhost:8000
+```
+
+## Qiita APIトークンの設定
+### 1. Qiitaのアクセストークンを取得
+Qiitaのアカウントからアクセストークンを生成します。
+参考: https://qiita.com/maiamea/items/680cca06f7825595cba0
+
+### 2. 環境変数に設定
+`.env.example`をコピーして`.env`ファイルを作成し、アクセストークンを設定します。
+
+```bash
+cp .env.example .env
+```
+
+`.env`ファイルを開いて、以下のようにアクセストークンを設定します。
+
+```dotenv
+QIITA_ACCESS_TOKEN=your_qiita_access_token
+```
+
+## API仕様
+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ aws dynamodb create-table \
 ### 1. Qiitaのアクセストークンを取得
 
 Qiitaのアカウントからアクセストークンを生成します。
-参考: https://qiita.com/maiamea/items/680cca06f7825595cba0
+参考: 参考: [Qiita記事 (APIトークン取得手順)](https://qiita.com/maiamea/items/680cca06f7825595cba0)
 
 ### 2. 環境変数に設定
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ aws dynamodb create-table \
 ### 1. Qiitaのアクセストークンを取得
 
 Qiitaのアカウントからアクセストークンを生成します。
-参考: 参考: [Qiita記事 (APIトークン取得手順)](https://qiita.com/maiamea/items/680cca06f7825595cba0)
+参考: [Qiita記事 (APIトークン取得手順)](https://qiita.com/maiamea/items/680cca06f7825595cba0)
 
 ### 2. 環境変数に設定
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # Logleaf
 
 ## 環境構築
+
 ### 1. git clone
+
 ```bash
 git clone https://github.com/umekikazuya/logleaf.git
 cd logleaf
 ```
+
 ### 2. Dockerイメージのビルド & コンテナの起動
+
 ```bash
 docker-compose up --build
 ```
 
 ### 3. DynamoDB初期セットアップ
+
 ```bash
 aws dynamodb create-table \
   --table-name leaves \
@@ -26,11 +31,14 @@ aws dynamodb create-table \
 ```
 
 ## Qiita APIトークンの設定
+
 ### 1. Qiitaのアクセストークンを取得
+
 Qiitaのアカウントからアクセストークンを生成します。
 参考: https://qiita.com/maiamea/items/680cca06f7825595cba0
 
 ### 2. 環境変数に設定
+
 `.env.example`をコピーして`.env`ファイルを作成し、アクセストークンを設定します。
 
 ```bash
@@ -44,4 +52,3 @@ QIITA_ACCESS_TOKEN=your_qiita_access_token
 ```
 
 ## API仕様
-

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,27 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', '${_IMAGE}', '.']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '${_IMAGE}']
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - logleaf-api
+      - --image=${_IMAGE}
+      - --region=asia-northeast1
+      - --platform=managed
+      - --allow-unauthenticated
+      - --project=momenture
+
+images:
+  - '${_IMAGE}'
+
+substitutions:
+  _IMAGE: 'gcr.io/$PROJECT_ID/logleaf-api:latest'
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,11 +1,14 @@
 steps:
-  - name: 'gcr.io/cloud-builders/docker'
+  - id: docker-build
+    name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', '${_IMAGE}', '.']
 
-  - name: 'gcr.io/cloud-builders/docker'
+  - id: docker-push
+    name: 'gcr.io/cloud-builders/docker'
     args: ['push', '${_IMAGE}']
 
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  - id: deploy
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: gcloud
     args:
       - run
@@ -15,7 +18,7 @@ steps:
       - --region=asia-northeast1
       - --platform=managed
       - --allow-unauthenticated
-      - --project=momenture
+      - --project=${PROJECT_ID}
 
 images:
   - '${_IMAGE}'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,7 +21,7 @@ images:
   - '${_IMAGE}'
 
 substitutions:
-  _IMAGE: 'gcr.io/$PROJECT_ID/logleaf-api:latest'
+  _IMAGE: 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/logleaf-api-repo/logleaf-api:latest'
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
This pull request introduces several updates to the `logleaf` project, including changes to Docker configurations, deployment automation, and documentation. The most significant changes involve updating the Dockerfiles, adding a Cloud Build configuration, and enhancing the README with setup and API token instructions.

### Docker Configuration Updates:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R12-L14): Added `.env` file copying for runtime configuration and removed duplicate `EXPOSE 8082` lines.
* [`Dockerfile.dev`](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL1-L8): Updated syntax to Dockerfile version 1, removed `EXPOSE 8080`, and clarified the purpose of the development Dockerfile.

### Deployment Automation:
* [`cloudbuild.yaml`](diffhunk://#diff-0b4a5fc26445836e6672c426692297004cfaba21997343b63e6f58b946bd2a5cR1-R27): Added a Google Cloud Build configuration to automate Docker image building, pushing, and deploying the `logleaf-api` service to a managed Cloud Run platform.

### Documentation Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R47): Added detailed instructions for environment setup, including cloning the repository, building Docker images, setting up DynamoDB, and configuring Qiita API tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - 新しいREADME.mdを追加し、セットアップ手順や環境変数の設定方法、DynamoDBテーブルの初期化方法、Qiita APIトークンの取得方法を記載しました。

- **新機能**
  - Google Cloud Build用のcloudbuild.yamlを追加し、Dockerイメージのビルド・デプロイを自動化しました。

- **リファクタ**
  - Dockerfileの重複したEXPOSE行を削除し、ポート設定を整理しました。
  - Dockerfile.devでポート番号を8080から8082に変更し、Dockerfile構文ディレクティブを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->