### PR TITLE
fix: cloudbuild.yamlの_IMAGE変数をプロジェクトIDから固定値に変更

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,7 +24,7 @@ images:
   - '${_IMAGE}'
 
 substitutions:
-  _IMAGE: 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/logleaf-api-repo/logleaf-api:latest'
+  _IMAGE: 'asia-northeast1-docker.pkg.dev/momenture/logleaf-api-repo/logleaf-api:latest'
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
This pull request includes a small change to the `cloudbuild.yaml` file. The change updates the `_IMAGE` substitution to use a new repository path, replacing `$PROJECT_ID` with the hardcoded `momenture` project identifier.